### PR TITLE
install nlohmann/json from package like ROOT does

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ RUN install-ubuntu-packages \
     libxpm-dev \
     libz-dev \
     libzstd-dev \
+    nlohmann-json3-dev \
     srm-ifce-dev \
     libgsl-dev
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Software Package | Version | Construction Process
 [Ubuntu Server](https://ubuntu.com/) | 24.04 | Base Image
 [Python](https://www.python.org/) | 3.12.3 | From Ubuntu Repos
 [cmake](https://cmake.org/) | 3.28.3 | From Ubuntu Repos
-[Boost](https://www.boost.org/doc/libs/1_74_0/) | 1.83.0 | From Ubuntu Repos
+[Boost](https://www.boost.org/doc/libs/1_83_0/) | 1.83.0 | From Ubuntu Repos
 [XercesC](http://xerces.apache.org/xerces-c/) | 3.3.0 | Built from source
 [LHAPDF](https://www.lhapdf.org/) | 6.5.5 | Built from source
 [Pythia8](https://pythia.org/) | 8.313 | Built from source
-[nlohmann/json](https://json.nlohmann.me/) | 3.10.5 | From Ubuntu Repos
+[nlohmann/json](https://json.nlohmann.me/) | 3.11.3 | From Ubuntu Repos
 [ROOT](https://root.cern.ch/) | 6.34.04 | Built from source
 [Geant4](https://geant4.web.cern.ch/) | [LDMX.10.2.3\_v0.6](https://github.com/LDMX-Software/geant4/tree/LDMX.10.2.3_v0.6) | Built from source
 [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) | 3.4.0 | Built from source

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Software Package | Version | Construction Process
 [XercesC](http://xerces.apache.org/xerces-c/) | 3.3.0 | Built from source
 [LHAPDF](https://www.lhapdf.org/) | 6.5.5 | Built from source
 [Pythia8](https://pythia.org/) | 8.313 | Built from source
+[nlohmann/json](https://json.nlohmann.me/) | 3.10.5 | From Ubuntu Repos
 [ROOT](https://root.cern.ch/) | 6.34.04 | Built from source
 [Geant4](https://geant4.web.cern.ch/) | [LDMX.10.2.3\_v0.6](https://github.com/LDMX-Software/geant4/tree/LDMX.10.2.3_v0.6) | Built from source
 [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) | 3.4.0 | Built from source

--- a/docs/src/ubuntu-packages.md
+++ b/docs/src/ubuntu-packages.md
@@ -70,6 +70,7 @@ libxmu-dev | low-level window management (ROOT GUI)
 libxpm-dev | low-level window management (ROOT GUI)
 libz-dev | Data compression in ROOT serialization
 libzstd-dev | Data compression in ROOT serialization
+nlohmann-json3-dev | JSON reading/writing in ROOT and ldmx-sw
 srm-ifce-dev | [srm-ifce](https://github.com/cern-fts/srm-ifce) client side access of distributed storage within ROOT
 libgsl-dev | GNU Scientific Library for numerical calculations in ROOT MathMore (needed for GENIE)
 liblog4cpp5-dev | C++ Logging Library used in GENIE


### PR DESCRIPTION
I am adding a new package to the container, here are the details.
ROOT will build in nlohmann/json if it is not available already and we want a JSON reader/writer anyways, so I'm installing it from Ubuntu repos like ROOT does in its official images.

### What new packages does this PR add to the development image?
- nlohmann/json

## Check List
- [x] ~I~ CI successfully built the container using docker
<!--
cd dev-build-context 
git checkout my-updates
docker build . -t ldmx/local:temp-tag
-->
- [ ] ~I~ CI was able to build ldmx-sw using this new container build
<!--
# outline of build instructions
cd ldmx-sw
just use ldmx/local:temp-tag
just configure
just build
-->
- [ ] ~I~ CI was able to test run a small simulation and reconstruction inside this container
<!--
# outline of test instructions
cd ldmx-sw/build
denv ctest
denv LDMX_NUM_EVENTS=10 LDMX_RUN_NUMBER=1 fire ../.github/validation_samples/inclusive/config.py
-->
- [x] I was able to successfully use the new packages.
<!-- Explain what you did to test them below. -->
I wanted to make sure that we could use `find_package` in ldmx-sw to deduce if nlohmann/json is available.
If it isn't, we could then use `FetchContent` to make sure that ldmx-sw can still be built with older images.
Added a line to `ldmx-sw/CMakeLists.txt`:
```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index e3e0c698..98e427e9 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ project(LDMX_SW VERSION ${LDMXSW_VERSION_NUM}
                 LANGUAGES CXX    
 )
 
+find_package(nlohmann_json 3.10.5 REQUIRED)
+
 set(CMAKE_CXX_STANDARD 20)
 
 # Load additional macros used by this project. 
```
which gives (when running `just configure` after `just use ldmx/dev:global-install-nlohmann-json`):
```
-- Found nlohmann_json: /usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found suitable version "3.11.3", minimum required is "3.10.5") 
```