### PR TITLE
tidy python packages to only do main, parent packages

### DIFF
--- a/python_packages.txt
+++ b/python_packages.txt
@@ -1,29 +1,16 @@
-contourpy
-cycler
-Cython
-fonttools
-joblib
-kiwisolver
-llvmlite
-matplotlib
-mplhep
-mplhep-data
-numba
-numpy
-packaging
-pandas
-Pillow
-pip
-pyparsing
-python-dateutil
-pytz
-scikit-learn
-scipy
-setuptools
-six
-threadpoolctl
-uhi
-uproot
-wheel
-xgboost
+# meta-package containing HEP tools like mplhep, uproot, awkward, etc...
+# which also brings in matplotlib and many others
+scikit-hep==2025.1.1
+# HEPMC IO in Python, not included in scikit-hep for some reason
 pyhepmc
+# update packages related to python packaging
+pip
+wheel
+setuptools
+# write C extensions for Python
+Cython
+# pre-compile python functions in a numpy-aware way
+numba
+# ML training/testing libraries
+scikit-learn
+xgboost


### PR DESCRIPTION
I am adding a new package to the container, here are the details.

### What new packages does this PR add to the development image?
Some new packages are now included due to bringing in the `scikit-hep` metapackage (e.g. `awkward`).

## Check List
- [x] I successfully built the container using docker
<!--
cd dev-build-context 
git checkout my-updates
docker build . -t ldmx/local:temp-tag
-->
- [x] I was able to build ldmx-sw using this new container build
<!--
# outline of build instructions
cd ldmx-sw
just use ldmx/local:temp-tag
just configure
just build
-->
- [x] I was able to test run a small simulation and reconstruction inside this container
<!--
# outline of test instructions
cd ldmx-sw/build
denv ctest
denv LDMX_NUM_EVENTS=10 LDMX_RUN_NUMBER=1 fire ../.github/validation_samples/inclusive/config.py
-->
- [ ] I was able to successfully use the new packages.
<!-- Explain what you did to test them below. -->
